### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # cog-molmo-7b-d
+
+[![Try a demo on Replicate](https://replicate.com/zsxkib/molmo-7b/badge)](https://replicate.com/zsxkib/molmo-7b)
+
 Replicate Cog for allenai/Molmo-7B-D-0924


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.